### PR TITLE
Refactored thresholding to reflect code changes

### DIFF
--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -354,6 +354,11 @@ class castTest : public Test {
     Mat computeBaseline(const Mat &src) const { Mat dst; src.convertTo(dst, CV_32F); return dst; }
 };
 
+class thresholdTest : public Test {
+    const char *function() const { return "threshold{127}"; }
+    Mat computeBaseline(const Mat &src) const { Mat dst; threshold(src, dst, 127, 1, THRESH_BINARY); return dst; }
+};
+
 void help()
 {
     printf("Usage:\n"
@@ -405,6 +410,7 @@ int main(int argc, char *argv[])
         lua_close(L);
     } else {
         printf("Function \tType \tSize \tExecution \tSpeedup\n");
+        thresholdTest().run();
         addTest().run();
         subtractTest().run();
         multiplyTest().run();

--- a/likely.cpp
+++ b/likely.cpp
@@ -1116,6 +1116,23 @@ class castOperation : public BinaryOperation
 };
 LIKELY_REGISTER(castOperation)
 
+class thresholdOperation : public BinaryOperation
+{
+    string name() const { return "threshold"; }
+    TypedValue callBinary(KernelBuilder &kernel, const KernelInfo &info, TypedValue x, TypedValue t) const
+    {
+         (void) info;
+         likely_type type = likely_type_from_types(x, t);
+         x = kernel.cast(x, type);
+         t = kernel.cast(t, type);
+         Value *comp = likely_floating(type) ? kernel.b->CreateFCmpOLE(x, t) : (likely_signed(type) ? kernel.b->CreateICmpSLE(x, t) : kernel.b->CreateICmpULE(x, t));
+         TypedValue high = kernel.constant(1.0, type);
+         TypedValue low = kernel.constant(0.0, type);
+         return TypedValue(kernel.b->CreateSelect(comp, low, high), type);
+    }
+};
+LIKELY_REGISTER(thresholdOperation)
+
 class ArithmeticOperation : public BinaryOperation
 {
     TypedValue callBinary(KernelBuilder &kernel, const KernelInfo &info, TypedValue arg1, TypedValue arg2) const


### PR DESCRIPTION
I refactored the threshold code to reflect the new code architecture but I'm running into a somewhat strange issue. This code worked before the refactoring and currently passes the benchmark test (its outputs match opencv's) but it isn't rendering properly in Dream. It is black except for when thresholded at a negative value between 0 and -127, is this something that I am doing wrong or potentially a bug in Dream?
